### PR TITLE
Fixed 039 Mad Libs

### DIFF
--- a/039_madlibs/P5/index.html
+++ b/039_madlibs/P5/index.html
@@ -1,14 +1,20 @@
+<!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8">
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.5.1/tabletop.min.js'></script>
-    <script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.min.js"></script>
-    
-    <script language="javascript" type="text/javascript" src="sketch.js"></script>
-  </head>
 
-  <body>
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <meta charset="utf-8" />
+
+</head>
+
+<body>
+  <script src="sketch.js"></script>
     <h1>MadLibs</h1>
     <p>_____________! they said ________ as they jumped into their _____________ and flew off with their __________ __________."</p>
-  </body>
+</body>
+
 </html>

--- a/039_madlibs/P5/sketch.js
+++ b/039_madlibs/P5/sketch.js
@@ -10,11 +10,28 @@ var txt =
 
 function setup() {
   noCanvas();
-  Tabletop.init({
-    key: '15WyEmfu6B1UCzzqeacYnzI8lutrxF6uWvFDiSteBqTs',
-    callback: gotData,
-    simpleSheet: true
-  });
+  // Tabletop.init({
+  //   key: '15WyEmfu6B1UCzzqeacYnzI8lutrxF6uWvFDiSteBqTs',
+  //   callback: gotData,
+  //   simpleSheet: true
+  // });
+
+  // Unfortunately since 2020 tabletop.js has been deprecated
+  // because of some changes that Google had made. To learn
+  // more about it, visit https://github.com/jsoma/tabletop
+
+  // In this example, the library Papa Parse has been used
+  // in a very similar fashion, so do something like this
+  // instead. Keep in mind that the Google Sheet link has 
+  // to a CSV link, rather than a web page!
+   Papa.parse('https://docs.google.com/spreadsheets/d/e/2PACX-1vSiJDczupcvlAJxd70RJ9hZina9cqweCiTj1EkYrH_17FhFBjdMFTEY2TOMmhwGBHGR05y7QRXLNbo6/pub?output=csv', {
+    download: true,
+    header: true,
+    complete: function(results) {
+      var stuff = results.data
+      data = stuff
+    }
+  })
 
   var button = createButton('generate madlib');
   button.mousePressed(generate);
@@ -31,6 +48,6 @@ function generate() {
   createP(madlib);
 }
 
-function gotData(stuff, tabletop) {
-  data = stuff;
-}
+// function gotData(stuff, tabletop) {
+//   data = stuff;
+// }


### PR DESCRIPTION
This PR fixes the code in 039 Mad Libs Generator.

Because of some changes in Google Sheets `tabletop.js` has been deprecated since 2020. But something similar is possible to do with the Papa Parse library. I have made changes as per that.

Tagging @shiffman to change the [web editor version](https://editor.p5js.org/codingtrain/sketches/8gVGg0VR3) as well