### PR TITLE
feat: disable the key opposite to the direction

### DIFF
--- a/003_Snake_game/P5/sketch.js
+++ b/003_Snake_game/P5/sketch.js
@@ -6,6 +6,13 @@
 let s;
 let scl = 20;
 let food;
+/**
+ * 0: Up
+ * 1: Down
+ * 2: Left
+ * 3: Right
+ */
+let direction = 3;
 
 function setup() {
   createCanvas(600, 600);
@@ -38,13 +45,17 @@ function draw() {
 }
 
 function keyPressed() {
-  if (keyCode === UP_ARROW) {
+  if (keyCode === UP_ARROW && direction != 1) {
+    direction = 0;
     s.dir(0, -1);
-  } else if (keyCode === DOWN_ARROW) {
+  } else if (keyCode === DOWN_ARROW && direction != 0) {
+    direction = 1;
     s.dir(0, 1);
-  } else if (keyCode === RIGHT_ARROW) {
+  } else if (keyCode === RIGHT_ARROW && direction != 2) {
+    direction = 3;
     s.dir(1, 0);
-  } else if (keyCode === LEFT_ARROW) {
+  } else if (keyCode === LEFT_ARROW && direction != 3) {
+    direction = 2;
     s.dir(-1, 0);
   }
 }

--- a/003_Snake_game/P5/snake.js
+++ b/003_Snake_game/P5/snake.js
@@ -11,7 +11,7 @@ function Snake() {
   this.total = 0;
   this.tail = [];
 
-  this.eat = function(pos) {
+  this.eat = function (pos) {
     let d = dist(this.x, this.y, pos.x, pos.y);
     if (d < 1) {
       this.total++;
@@ -21,24 +21,24 @@ function Snake() {
     }
   };
 
-  this.dir = function(x, y) {
+  this.dir = function (x, y) {
     this.xspeed = x;
     this.yspeed = y;
   };
 
-  this.death = function() {
+  this.death = function () {
     for (let i = 0; i < this.tail.length; i++) {
       let pos = this.tail[i];
       let d = dist(this.x, this.y, pos.x, pos.y);
       if (d < 1) {
-        console.log('starting over');
+        console.log("starting over");
         this.total = 0;
         this.tail = [];
       }
     }
   };
 
-  this.update = function() {
+  this.update = function () {
     for (let i = 0; i < this.tail.length - 1; i++) {
       this.tail[i] = this.tail[i + 1];
     }
@@ -53,7 +53,7 @@ function Snake() {
     this.y = constrain(this.y, 0, height - scl);
   };
 
-  this.show = function() {
+  this.show = function () {
     fill(255);
     for (let i = 0; i < this.tail.length; i++) {
       rect(this.tail[i].x, this.tail[i].y, scl, scl);


### PR DESCRIPTION
When the length is 2, choosing the direction opposite to the forward direction will not be judged as death.
But when the length is greater than 2, this situation will be judged as death.
So I looked for related games and found that they all disable the direction key opposite to the current direction.